### PR TITLE
Use vendor instead of community for the Galaxy roles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 *.log
 **/*.retry
-community
+vendor

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,6 +1,6 @@
 [defaults]
 # Roles
-roles_path = ./community:./roles
+roles_path = ./vendor:./roles
 
 # Hosts
 inventory = ./inventory/hosts


### PR DESCRIPTION
Use `vendor` to put the Galaxy Roles.